### PR TITLE
Add optional rpcmiddleware to lnd start flags

### DIFF
--- a/lnd/spawn_lnd_docker.js
+++ b/lnd/spawn_lnd_docker.js
@@ -106,6 +106,8 @@ module.exports = (args, cbk) => {
           `--listen=0.0.0.0:9735`,
           '--nobootstrap',
           `--rpclisten=0.0.0.0:10009`,
+          `--rpcmiddleware.enable`,
+          `--rpcmiddleware.intercepttimeout=4s`,
           '--trickledelay=1',
           '--unsafe-disconnect',
           '--watchtower.externalip', `127.0.0.1:9911`,


### PR DESCRIPTION
This will help with testing interceptors, the middleware is optional. 